### PR TITLE
Remove error control operator 

### DIFF
--- a/src/Exceptions/ArrayKeyNotFound.php
+++ b/src/Exceptions/ArrayKeyNotFound.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace CoinParams\Exceptions;
+
+use Exception;
+
+class ArrayKeyNotFound extends Exception
+{
+
+}

--- a/src/Internal.php
+++ b/src/Internal.php
@@ -11,16 +11,16 @@ class Internal
     /**
      * @param $array array
      * @param $key string
-     * @param bool|string $execption: type or message to throw an exeption with your message or false to return null.
+     * @param bool|string $exception: type or message to throw an exception with your message or false to return null.
      * @return null|mixed
      * @throws ArrayKeyNotFound
      */
-    public static function aget($array , $key , $execption = false)
+    public static function aget($array , $key , $exception = false)
     {
-        if (is_array($array) AND array_key_exists($key, $array) AND true == $array[$key]){
+        if (is_array($array) AND array_key_exists($key, $array)){
             return $array[$key];
-        }elseif ($execption){
-            $message = is_string($execption) ? $execption : 'Array value not found for key ' . $key;
+        }elseif ($exception){
+            $message = is_string($exception) ? $exception : 'Array value not found for key ' . $key;
             throw new ArrayKeyNotFound($message);
         }else{
             return null;

--- a/src/Internal.php
+++ b/src/Internal.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace CoinParams\BitWasp;
+
+
+use CoinParams\Exceptions\ArrayKeyNotFound;
+
+class Internal
+{
+    /**
+     * @param $array array
+     * @param $key string
+     * @param bool|string $execption: type or message to throw an exeption with your message or false to return null.
+     * @return null|mixed
+     * @throws ArrayKeyNotFound
+     */
+    public static function aget($array , $key , $execption = false)
+    {
+        if (is_array($array) AND array_key_exists($key, $array) AND true == $array[$key]){
+            return $array[$key];
+        }elseif ($execption){
+            $message = is_string($execption) ? $execption : 'Array value not found for key ' . $key;
+            throw new ArrayKeyNotFound($message);
+        }else{
+            return null;
+        }
+    }
+}

--- a/src/MultiCoinNetwork.php
+++ b/src/MultiCoinNetwork.php
@@ -40,51 +40,57 @@ class MultiCoinNetwork extends Network {
         $this->signedMessagePrefix = $this->genSignedMessagePrefix($params);
         $this->p2pMagic            = $this->genP2pMagic($params);
     }
-    
+
     /**
-     * @param array $params  blockchain data from coinParams::get_coin_network()
+     * @param array $params blockchain data from coinParams::get_coin_network()
+     * @return array
+     * @throws \CoinParams\Exceptions\ArrayKeyNotFound
      */
     protected function genBase58PrefixMap($params) {
         
-        $prefixes = @$params['prefixes'];
+        $prefixes = Internal::aget($params, 'prefixes');
         
         // Prefer scripthash2 to scripthash. For coins like LTC that
         // changed p2sh prefix after-launch to differentiate from BTC.
         // Overrid this method if you need a different behavior.
-        $scripthash = @$prefixes['scripthash2'] ?
-                       $prefixes['scripthash2'] : $prefixes['scripthash'];
+        $scripthash = Internal::aget($prefixes, 'scripthash2') ?:  $prefixes['scripthash'];
         
         return [
-            self::BASE58_ADDRESS_P2PKH => $this->dh(@$prefixes['public']),
+            self::BASE58_ADDRESS_P2PKH => $this->dh(Internal::aget($prefixes, 'public')),
             self::BASE58_ADDRESS_P2SH => $this->dh($scripthash),
-            self::BASE58_WIF => $this->dh(@$prefixes['private']),
+            self::BASE58_WIF => $this->dh(Internal::aget($prefixes, 'private')),
         ];
     }
-    
+
     /**
-     * @param array $params  blockchain data from coinParams::get_coin_network()
+     * @param array $params blockchain data from coinParams::get_coin_network()
+     * @return array
+     * @throws \CoinParams\Exceptions\ArrayKeyNotFound
      */
     protected function genBech32PrefixMap($params) {
         $map = [];
-        if( @$params['prefixes']['bech32'] ) {
-            $map[self::BECH32_PREFIX_SEGWIT] = @$params['prefixes']['bech32'];
+        if( Internal::aget($params['prefixes'], 'bech32') ) {
+            $map[self::BECH32_PREFIX_SEGWIT] = $params['prefixes']['bech32'];
         }
         return $map;
     }
-    
+
 
     /**
-     * @param array $params  blockchain data from coinParams::get_coin_network()
+     * @param array $params blockchain data from coinParams::get_coin_network()
+     * @return array
+     * @throws \CoinParams\Exceptions\ArrayKeyNotFound
      */
     protected function genBip32PrefixMap($params) {
         return [
-            self::BIP32_PREFIX_XPUB => $this->nh(@$params['prefixes']['extended']['xpub']['public']),
-            self::BIP32_PREFIX_XPRV => $this->nh(@$params['prefixes']['extended']['xpub']['private']),
+            self::BIP32_PREFIX_XPUB => $this->nh(Internal::aget($params['prefixes']['extended']['xpub'], 'public')),
+            self::BIP32_PREFIX_XPRV => $this->nh(Internal::aget($params['prefixes']['extended']['xpub'], 'private')),
         ];
     }
-    
+
     /**
-     * @param array $params  blockchain data from coinParams::get_coin_network()
+     * @param array $params blockchain data from coinParams::get_coin_network()
+     * @return array
      */
     protected function genBip32ScriptTypeMap($params) {
         return [
@@ -92,19 +98,22 @@ class MultiCoinNetwork extends Network {
             self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
         ];
     }
-    
+
     /**
-     * @param array $params  blockchain data from coinParams::get_coin_network()
+     * @param array $params blockchain data from coinParams::get_coin_network()
+     * @return mixed
      */
     protected function genSignedMessagePrefix($params) {
         return $params['message_magic'];
     }
-    
+
     /**
-     * @param array $params  blockchain data from coinParams::get_coin_network()
+     * @param array $params blockchain data from coinParams::get_coin_network()
+     * @return string
+     * @throws \CoinParams\Exceptions\ArrayKeyNotFound
      */
     protected function genP2pMagic($params) {
-        return $this->nh(@$params['protocol']['magic']);
+        return $this->nh(Internal::aget($params['protocol'], 'magic'));
     }
     
     /**
@@ -130,7 +139,7 @@ class MultiCoinNetwork extends Network {
      *
      * @param integer $dec
      *
-     * @return normalized hex string
+     * @return string normalized hex string
      */
     private function dh($dec) {
         return $this->nh(dechex($dec));


### PR DESCRIPTION
Hi again, I have closed the previous PR and opened this one, please check if everything works.
You were depending on `@` a lot even in places that you don't have to. 
I couldn't do the tests well so I've left that for you since you're using your own library for tests.
I've made the following tests:
```
$array = ['working'=>'yes it is'];
var_dump(aget($_GET, 'test'));
var_dump(aget($_GET, ''));
var_dump(aget($_POST, 'test'));
var_dump(aget($array, 'working'));
var_dump(aget($_GET, 'test' , false));
var_dump(aget($_GET, 'test' , true));
var_dump(aget($array, 'notExist' , 'Sorry, we couldnt find your key'));
Response: 
NULL
NULL
NULL
string(9) "yes it is"
NULL
PHP Fatal error:  Uncaught Exception: Array value not found for key test in /test.php:38

```

Summery:
- a new function added `aget` to Internal class.
- `aget` checks if an array key exists and value isn't false and returns null or
throws an exception with a custom message if exists or the default message.
- Replaced @ with a new function `aget`.
- Made a new directory for exceptions.