### PR TITLE
Updated Bitwasp version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Unlicense",
 
     "require": {
-        "bitwasp/bitcoin": "0.0.35.1",
+        "bitwasp/bitcoin": "^1.0.1",
         "dan-da/coinparams": "0.2.6",
         "ext-json": "*",
         "php": ">=5.6"


### PR DESCRIPTION
updated composer error conflict to use with latest Bitwasp version

Trying to solve this error

Problem 1
    - Root composer.json requires dan-da/coinparams-bitwasp-addon dev-master -> satisfiable by dan-da/coinparams-bitwasp-addon[dev-master].
    - dan-da/coinparams-bitwasp-addon dev-master requires bitwasp/bitcoin 0.0.35.1 -> found bitwasp/bitcoin[v0.0.35.1] but it conflicts with your root composer.json require (dev-master as v1.0.1).