### PR TITLE
Require Bitwasp "^1.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Unlicense",
 
     "require": {
-        "bitwasp/bitcoin": "0.0.35.1",
+        "bitwasp/bitcoin": "^1.0",
         "dan-da/coinparams": "0.2.6",
         "ext-json": "*",
         "php": ">=5.6"


### PR DESCRIPTION
Require Bitwasp "^1.0" for old version causing conflict on composer